### PR TITLE
Use region variable in provider section

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 provider "ibm" {
   bluemix_api_key = "${var.bluemix_api_key}"
+  region = "${var.region}"
 }
 
 data "ibm_org" "org" {


### PR DESCRIPTION
Using the region variable in the provider section makes it possible to deploy to the template in regions other than us-south.